### PR TITLE
ARCH-1615 - Update syntax for setting outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ jobs:
       uses: actions/checkout@v3
     - name: IIS App Pool Status
       id: get-status
-      uses: 'im-open/app-pool-status@v1.0.0'
+      uses: 'im-open/app-pool-status@v1.1.0'
       with:
         server: ${{ env.server }}
         app-pool-name: ${{ env.pool-name }}

--- a/iis_action.ps1
+++ b/iis_action.ps1
@@ -29,6 +29,6 @@ $result = Invoke-Command -ComputerName $server `
     -SessionOption $so `
     -ScriptBlock $script
 
-Write-Output "app-pool-status=$result" >> $GITHUB_OUTPUT
+"app-pool-status=$result" >> $env:GITHUB_OUTPUT
 
 Write-Output "IIS $display_action_past_tense."

--- a/iis_action.ps1
+++ b/iis_action.ps1
@@ -29,6 +29,6 @@ $result = Invoke-Command -ComputerName $server `
     -SessionOption $so `
     -ScriptBlock $script
 
-Write-Output "::set-output name=app-pool-status::$result"
+Write-Output "app-pool-status=$result" >> $GITHUB_OUTPUT
 
 Write-Output "IIS $display_action_past_tense."


### PR DESCRIPTION
# Summary of PR changes

-  Update syntax for setting outputs to comply with the [GitHub's new recommendations](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands) to avoid logging untrusted data.
- The output is set in powershell so the syntax is slightly different than the regular bash syntax.

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The examples in the repository's `README.md` have been updated with the new version.  
  - See the *Incrementing the Version* section of the repository's README.md for more details on how the version will be incremented.
- [x] The action code does not contain sensitive information.
